### PR TITLE
Add support for gcloud deployment

### DIFF
--- a/org.alloytools.alloy.grpc/README.md
+++ b/org.alloytools.alloy.grpc/README.md
@@ -118,6 +118,11 @@ docker build -f org.alloytools.alloy.grpc/Dockerfile -t alloy-grpc:latest .
 docker run -p 50051:50051 alloy-grpc:latest
 ```
 
+### GCloud deployment
+```bash
+gcloud builds submit --config=org.alloytools.alloy.grpc/cloudbuild.yaml .
+```
+
 ### Environment Variables
 
 | Variable | Default | Description |

--- a/org.alloytools.alloy.grpc/cloudbuild.yaml
+++ b/org.alloytools.alloy.grpc/cloudbuild.yaml
@@ -1,0 +1,38 @@
+steps:
+  # Build the Docker image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: 
+      - 'build'
+      - '-f'
+      - 'org.alloytools.alloy.grpc/Dockerfile'
+      - '-t'
+      - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'
+      - '.'
+
+  # Push the image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: 
+      - 'push'
+      - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'
+
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'morph-alloy-grpc'
+      - '--image'
+      - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'
+      - '--region'
+      - 'us-west1'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--max-instances'
+      - '1'
+      - '--port'
+      - '50051'
+
+images:
+  - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'


### PR DESCRIPTION
Add a cloud build config file with steps to build, push and deploy the alloy grpc server docker file.

gcloud builds submit --config=org.alloytools.alloy.grpc/cloudbuild.yaml .