### PR TITLE
Include location of error in grpc response

### DIFF
--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/impl/AlloySolverServiceImpl.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/impl/AlloySolverServiceImpl.java
@@ -108,7 +108,7 @@ public class AlloySolverServiceImpl extends SolverServiceGrpc.SolverServiceImplB
 
         } catch (Err err) {
             responseObserver.onError(Status.fromCode(Status.Code.INTERNAL)
-                .withDescription("Alloy error: " + err.getMessage())
+                .withDescription("Alloy error: " + err.toString())
                 .asRuntimeException());
             
         } catch (Exception ex) {

--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ModelLoader.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ModelLoader.java
@@ -81,7 +81,7 @@ public class ModelLoader {
             return ModelLoadResult.success(world, commands);
             
         } catch (Err err) {
-            return ModelLoadResult.error("Parse error: " + err.getMessage());
+            return ModelLoadResult.error("Parse error: " + err.toString());
         } catch (Exception ex) {
             return ModelLoadResult.error("Unexpected error: " + ex.getMessage());
         }


### PR DESCRIPTION
$ grpcurl -plaintext -d '{
  "model_content": "sig Person {}\nrun {} for 3\n {",
  "output_format": "OUTPUT_FORMAT_JSON",
  "solver_type": "SOLVER_TYPE_SAT4J"
}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve ERROR:
  Code: InvalidArgument
  Message: Parse error: Syntax error in /tmp/alloy_heredoc6245923478203039575.als at line 3 column 2:
There are 5 possible tokens that can appear here:
enum fun let open pred