### PR TITLE
Change gRPC solver to execute all commands by default

### DIFF
--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ProtocolBufferConverter.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ProtocolBufferConverter.java
@@ -283,4 +283,23 @@ public class ProtocolBufferConverter {
                 return SolverType.SOLVER_TYPE_UNSPECIFIED;
         }
     }
+
+    /**
+     * Create SolveResponse for combined results from multiple commands.
+     */
+    public static SolveResponse createCombinedResponse(boolean anySatisfiable, String combinedResults, 
+                                                       long totalSolvingTimeMs, String solverUsed, 
+                                                       String executedCommand) {
+        SolutionMetadata metadata = SolutionMetadata.newBuilder()
+            .setSolvingTimeMs(totalSolvingTimeMs)
+            .setSolverUsed(solverUsed != null ? solverUsed : "unknown")
+            .setExecutedCommand(executedCommand)
+            .build();
+            
+        return SolveResponse.newBuilder()
+            .setSatisfiable(anySatisfiable)
+            .setSolutionData(combinedResults)
+            .setMetadata(metadata)
+            .build();
+    }
 }

--- a/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/BasicSolvingIntegrationTest.java
+++ b/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/BasicSolvingIntegrationTest.java
@@ -97,6 +97,7 @@ public class BasicSolvingIntegrationTest {
             .setModelContent(UNSATISFIABLE_MODEL)
             .setOutputFormat(OutputFormat.OUTPUT_FORMAT_TEXT)
             .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .setCommand("0")
             .build();
 
         service.solve(request, responseObserver);

--- a/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/OutputFormatIntegrationTest.java
+++ b/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/OutputFormatIntegrationTest.java
@@ -51,6 +51,7 @@ public class OutputFormatIntegrationTest {
             .setModelContent(SIMPLE_MODEL)
             .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
             .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .setCommand("0")
             .build();
 
         // Execute request
@@ -88,6 +89,7 @@ public class OutputFormatIntegrationTest {
             .setModelContent(SIMPLE_MODEL)
             .setOutputFormat(OutputFormat.OUTPUT_FORMAT_XML)
             .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .setCommand("0")
             .build();
 
         // Execute request


### PR DESCRIPTION
The Alloy gRPC service was executing only a single command per request, requiring clients to make multiple calls to run all commands in a model.

Modified the solve method to execute all commands in the Alloy file by default when no specific command is requested, combining results into a single response. Clients can still request specific commands by providing a command identifier (index or name).

mohit@wonk:~/morph/org.alloytools.alloy$ ./gradlew :org.alloytools.alloy.grpc:test

BUILD SUCCESSFUL in 1s
9 actionable tasks: 9 up-to-date

2025-08-21  Starting Alloy file validation for: /tmp/generated/project-standalone_mg_gcs/alloy/l2.als 2025-08-21  Validating /tmp/generated/project-standalone_mg_gcs/alloy/l2.als using Alloy server at localhost:50051 2025-08-21  Sending validation request...
2025-08-21  Alloy solver response - satisfiable: True, error_message: '', solution_data length: 7877 2025-08-21  Alloy solver metadata - solving_time_ms: 1189, solver_used: 'sat4j', executed_command: 'All 4 commands' 2025-08-21  Validation results for /tmp/generated/project-standalone_mg_gcs/alloy/l2.als: