### PR TITLE
Add multi-file support to Alloy gRPC server

### DIFF
--- a/org.alloytools.alloy.grpc/README.md
+++ b/org.alloytools.alloy.grpc/README.md
@@ -48,15 +48,46 @@ The service provides two main endpoints:
 
 ```protobuf
 message SolveRequest {
+  // Single-file mode (backward compatible)
   string model_content = 1;        // Alloy model source code
+  
+  // Multi-file mode (NEW)
+  repeated AlloyFile files = 6;    // Multiple Alloy files
+  string main_file = 7;            // Entry point file
+  
+  // Common parameters
   OutputFormat output_format = 2;  // JSON, XML, TEXT, TABLE
   SolverType solver_type = 3;      // SAT4J, MINISAT, GLUCOSE, etc.
   SolverOptions solver_options = 4; // Optional solver configuration
   string command = 5;              // Optional command to execute
 }
+
+message AlloyFile {
+  string filename = 1;             // File path (e.g., "util.als", "models/core.als")
+  string content = 2;              // Complete file content
+}
 ```
 
-### Client Examples
+#### Multi-File Mode Features
+
+- **Cross-file imports**: Use `open` directive to import other modules
+- **Parameterized modules**: Support for generic modules with type parameters  
+- **Directory structure**: Preserve relative paths in filenames
+- **Module aliases**: Support for `open module as alias` syntax
+- **Backward compatibility**: Single-file mode continues to work unchanged
+
+### Single-File Examples
+
+#### Using grpcurl
+
+```bash
+# Simple model solving
+grpcurl -plaintext -d '{
+  "model_content": "sig Person {} run {} for 3",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+```
 
 #### Python
 
@@ -77,6 +108,72 @@ request = SolveRequest(
 response = stub.Solve(request)
 print(f"Satisfiable: {response.satisfiable}")
 print(f"Solution: {response.solution_data}")
+```
+
+### Multi-File Examples
+
+#### Basic Import
+
+```bash
+grpcurl -plaintext -d '{
+  "files": [
+    {
+      "filename": "util.als",
+      "content": "module util\nsig Util {}\npred hasUtil { some Util }"
+    },
+    {
+      "filename": "main.als", 
+      "content": "module main\nopen util\nrun { hasUtil } for 3"
+    }
+  ],
+  "main_file": "main.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+```
+
+#### Parameterized Modules
+
+```bash
+grpcurl -plaintext -d '{
+  "files": [
+    {
+      "filename": "library.als",
+      "content": "module library[T]\nsig Container { items: set T }\npred hasItems[c: Container] { some c.items }"
+    },
+    {
+      "filename": "application.als",
+      "content": "module application\nopen library[String] as lib\nsig String {}\nrun { some c: lib/Container | lib/hasItems[c] } for 3"
+    }
+  ],
+  "main_file": "application.als",
+  "output_format": "OUTPUT_FORMAT_TEXT",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+```
+
+#### Nested Directory Structure
+
+```bash
+grpcurl -plaintext -d '{
+  "files": [
+    {
+      "filename": "util/base.als",
+      "content": "module util/base\nsig Base {}"
+    },
+    {
+      "filename": "util/derived.als", 
+      "content": "module util/derived\nopen util/base\nsig Derived extends Base {}"
+    },
+    {
+      "filename": "main.als",
+      "content": "module main\nopen util/derived\nrun { some Derived } for 3"
+    }
+  ],
+  "main_file": "main.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
 ```
 
 ## Testing
@@ -102,8 +199,11 @@ grpcurl -plaintext -d "$(jq -n \
   '{"model_content": $mc, "output_format": "OUTPUT_FORMAT_JSON", "solver_type": "SOLVER_TYPE_SAT4J"}')" \
   localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
 
-# Start the server and then run the test script
+# Start the server and run comprehensive tests
 ./org.alloytools.alloy.grpc/hacks/test-server.sh
+
+# Run multi-file specific tests
+./org.alloytools.alloy.grpc/hacks/test-multifile-examples.sh
 ```
 
 ## Deployment
@@ -184,6 +284,67 @@ The Alloy gRPC service module is organized into the following directory structur
 
 - **`hacks/`** - Utility scripts
   - `start-server.sh` - Script to start the server
-  - `test-server.sh` - Script to test server functionality
+  - `test-server.sh` - Script to test server functionality including multi-file tests
+  - `test-multifile-examples.sh` - Comprehensive multi-file scenario tests
 
 - **`Dockerfile`** - Docker configuration for containerized deployment
+
+## Troubleshooting
+
+### Server Issues
+- **Port already in use**: Change the port with `--args="8080"` or check if another instance is running
+- **Build failures**: Run `./gradlew clean :org.alloytools.alloy.grpc:build` to rebuild from scratch
+- **Java version**: Ensure Java 11+ is installed and `JAVA_HOME` is set correctly
+
+### Multi-File Import Issues
+- **Module not found**: Ensure the filename in `files` array exactly matches the `open` directive
+- **Case sensitivity**: Filenames are case-sensitive, verify exact spelling
+- **Main file not found**: The `main_file` must exactly match one of the filenames in the `files` array
+- **Circular imports**: Check for circular dependencies between modules
+- **Module name mismatch**: Module declaration should match the expected path structure
+
+### Example Debugging
+
+#### Wrong filename case
+```bash
+# ❌ This will fail
+{
+  "files": [{"filename": "Util.als", "content": "module util\n..."}],
+  "main_file": "Util.als"
+}
+
+# ✅ This works
+{
+  "files": [{"filename": "util.als", "content": "module util\n..."}],
+  "main_file": "util.als"
+}
+```
+
+#### Missing main file
+```bash
+# ❌ This will fail - main_file not in files array
+{
+  "files": [{"filename": "util.als", "content": "..."}],
+  "main_file": "main.als"
+}
+
+# ✅ This works
+{
+  "files": [
+    {"filename": "util.als", "content": "..."},
+    {"filename": "main.als", "content": "..."}
+  ],
+  "main_file": "main.als"
+}
+```
+
+### Performance Considerations
+- **Large models**: Consider increasing JVM heap size with `JAVA_OPTS=-Xmx4g`
+- **Many files**: File processing is optimized but very large file sets may need tuning
+- **Temporary files**: The server creates temporary files for multi-file models - ensure adequate disk space
+
+### Common Error Messages
+- `"main_file must be specified when using multi-file mode"`: Set the `main_file` field
+- `"main_file 'X' not found in provided files"`: Add the main file to the `files` array
+- `"Cannot specify both model_content and files"`: Use either single-file or multi-file mode, not both
+- `"All files must have non-empty filenames"`: Check that every file in the `files` array has a filename

--- a/org.alloytools.alloy.grpc/hacks/test-multifile-examples.sh
+++ b/org.alloytools.alloy.grpc/hacks/test-multifile-examples.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# Comprehensive Multi-File Alloy gRPC Server Test Script
+# Tests complex multi-file scenarios including nested imports and real-world examples
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+NC='\033[0m' # No Color
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo -e "${BLUE}🧪 Testing Alloy Multi-File gRPC Server...${NC}"
+echo -e "${YELLOW}📍 Server should be running on localhost:50051${NC}"
+echo ""
+
+# Check if grpcurl exists in PATH or project root
+GRPCURL_CMD=""
+if command -v grpcurl &> /dev/null; then
+    GRPCURL_CMD="grpcurl"
+elif [ -f "$PROJECT_ROOT/grpcurl" ]; then
+    GRPCURL_CMD="$PROJECT_ROOT/grpcurl"
+else
+    echo -e "${RED}❌ grpcurl not found!${NC}"
+    echo "Please download grpcurl first:"
+    echo "curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz -o grpcurl.tar.gz"
+    echo "tar -xzf grpcurl.tar.gz"
+    exit 1
+fi
+
+cd "$PROJECT_ROOT"
+
+echo -e "${PURPLE}1. 📁 Address Book Example (2 Files):${NC}"
+"${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "names.als",
+      "content": "module names\n\nsig Name {}\nsig Addr {}\n\npred validName[n: Name] { some n }\npred validAddr[a: Addr] { some a }"
+    },
+    {
+      "filename": "addressbook.als",
+      "content": "module addressbook\nopen names\n\nsig Book {\n  entries: Name -> lone Addr\n}\n\nfact {\n  all n: Name, a: Addr | n->a in Book.entries => validName[n] and validAddr[a]\n}\n\nrun { some b: Book | #b.entries > 1 } for 4"
+    }
+  ],
+  "main_file": "addressbook.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Address book example passed${NC}"
+else
+    echo -e "${RED}❌ Address book example failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${PURPLE}2. 📁 Three-Level Import Chain:${NC}"
+"${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "base.als",
+      "content": "module base\n\nsig Element {}\npred hasElement { some Element }"
+    },
+    {
+      "filename": "middle.als",
+      "content": "module middle\nopen base\n\nsig Container {\n  contents: set Element\n}\n\npred hasContents[c: Container] {\n  some c.contents and hasElement\n}"
+    },
+    {
+      "filename": "top.als",
+      "content": "module top\nopen middle\n\nsig System {\n  containers: set Container\n}\n\nrun {\n  some s: System, c: s.containers |\n    hasContents[c]\n} for 3"
+    }
+  ],
+  "main_file": "top.als",
+  "output_format": "OUTPUT_FORMAT_TEXT",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Three-level import chain passed${NC}"
+else
+    echo -e "${RED}❌ Three-level import chain failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${PURPLE}3. 📁 Parameterized Module with Alias:${NC}"
+"${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "util/ordering.als",
+      "content": "module util/ordering[T]\n\none sig First, Last extends T {}\n\npred isOrdered {\n  First != Last\n  some First\n  some Last\n}"
+    },
+    {
+      "filename": "numbers.als",
+      "content": "module numbers\nopen util/ordering[Number] as ord\nsig Number {}\n\nrun {\n  ord/isOrdered\n} for 3"
+    }
+  ],
+  "main_file": "numbers.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Parameterized module with alias passed${NC}"
+else
+    echo -e "${RED}❌ Parameterized module with alias failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${PURPLE}4. 📁 Four-File Import Chain:${NC}"
+"${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "types.als",
+      "content": "module types\n\nsig Element {}"
+    },
+    {
+      "filename": "containers.als",
+      "content": "module containers\nopen types\n\nsig Container {\n  items: set Element\n}"
+    },
+    {
+      "filename": "operations.als",
+      "content": "module operations\nopen containers\n\npred hasItems[c: Container] {\n  some c.items\n}"
+    },
+    {
+      "filename": "main.als",
+      "content": "module main\nopen operations\n\nrun {\n  some c: Container | hasItems[c]\n} for 3"
+    }
+  ],
+  "main_file": "main.als",
+  "output_format": "OUTPUT_FORMAT_TEXT",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Four-file import chain passed${NC}"
+else
+    echo -e "${RED}❌ Four-file import chain failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${PURPLE}5. ❌ Error Test - Circular Import:${NC}"
+RESPONSE=$("${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "a.als",
+      "content": "module a\nopen b\nsig A {}"
+    },
+    {
+      "filename": "b.als",
+      "content": "module b\nopen a\nsig B {}"
+    }
+  ],
+  "main_file": "a.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve 2>&1)
+if echo "$RESPONSE" | grep -q "error_message\|ERROR"; then
+    echo -e "${GREEN}✅ Circular import error handling passed${NC}"
+else
+    echo -e "${RED}❌ Circular import should have failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${PURPLE}6. ❌ Error Test - Missing Import:${NC}"
+RESPONSE=$("${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "main.als",
+      "content": "module main\nopen nonexistent\nsig Main {}"
+    }
+  ],
+  "main_file": "main.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve 2>&1)
+if echo "$RESPONSE" | grep -q "error_message\|ERROR"; then
+    echo -e "${GREEN}✅ Missing import error handling passed${NC}"
+else
+    echo -e "${RED}❌ Missing import should have failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}🎉 All multi-file tests completed successfully!${NC}"
+echo -e "${YELLOW}📊 Multi-File Test Summary:${NC}"
+echo "  ✅ Address Book (Basic 2-file import)"
+echo "  ✅ Three-Level Import Chain"
+echo "  ✅ Parameterized Module with Directory Structure"
+echo "  ✅ Four-File Import Chain"
+echo "  ✅ Circular Import Error Handling"
+echo "  ✅ Missing Import Error Handling"
+echo ""
+echo -e "${BLUE}🚀 Multi-file Alloy gRPC functionality is working perfectly!${NC}"
+echo -e "${YELLOW}💡 These examples demonstrate:${NC}"
+echo "  • Cross-file symbol resolution"
+echo "  • Parameterized module imports"
+echo "  • Directory structure preservation"
+echo "  • Module aliases"
+echo "  • Proper error handling for invalid imports"

--- a/org.alloytools.alloy.grpc/hacks/test-server.sh
+++ b/org.alloytools.alloy.grpc/hacks/test-server.sh
@@ -106,6 +106,74 @@ else
 fi
 
 echo ""
+echo -e "${BLUE}7. 📁 Multi-File Model Test (Basic):${NC}"
+"${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "util.als", 
+      "content": "module util\nsig Util {}\npred hasUtil { some Util }"
+    },
+    {
+      "filename": "main.als", 
+      "content": "module main\nopen util\nrun { hasUtil } for 3"
+    }
+  ],
+  "main_file": "main.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Multi-file basic test passed${NC}"
+else
+    echo -e "${RED}❌ Multi-file basic test failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}8. 📁 Multi-File Model Test (Parameterized):${NC}"
+"${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "library.als", 
+      "content": "module library[T]\nsig Container { items: set T }\npred hasItems[c: Container] { some c.items }"
+    },
+    {
+      "filename": "application.als", 
+      "content": "module application\nopen library[Int] as lib\nrun { some c: lib/Container | lib/hasItems[c] } for 3"
+    }
+  ],
+  "main_file": "application.als",
+  "output_format": "OUTPUT_FORMAT_TEXT",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Multi-file parameterized test passed${NC}"
+else
+    echo -e "${RED}❌ Multi-file parameterized test failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}9. ❌ Multi-File Error Test (Missing Main File):${NC}"
+RESPONSE=$("${GRPCURL_CMD}" -plaintext -d '{
+  "files": [
+    {
+      "filename": "util.als", 
+      "content": "sig Util {}"
+    }
+  ],
+  "main_file": "missing.als",
+  "output_format": "OUTPUT_FORMAT_JSON",
+  "solver_type": "SOLVER_TYPE_SAT4J"
+}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve 2>&1)
+if echo "$RESPONSE" | grep -q "error_message"; then
+    echo -e "${GREEN}✅ Multi-file error handling test passed${NC}"
+else
+    echo -e "${RED}❌ Multi-file error handling test failed${NC}"
+    exit 1
+fi
+
+echo ""
 echo -e "${GREEN}🎉 All tests completed successfully!${NC}"
 echo -e "${YELLOW}📊 Test Summary:${NC}"
 echo "  ✅ Health Check"
@@ -114,5 +182,8 @@ echo "  ✅ Service Discovery"
 echo "  ✅ Simple Model Solving"
 echo "  ✅ Complex Model Solving"
 echo "  ✅ Error Handling"
+echo "  ✅ Multi-File Basic Model"
+echo "  ✅ Multi-File Parameterized Model"
+echo "  ✅ Multi-File Error Handling"
 echo ""
 echo -e "${BLUE}🚀 Your Alloy gRPC Server is working perfectly!${NC}"

--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/impl/AlloySolverServiceImpl.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/impl/AlloySolverServiceImpl.java
@@ -1,9 +1,12 @@
 package org.alloytools.alloy.grpc.impl;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.alloytools.alloy.grpc.proto.AlloyFile;
 import org.alloytools.alloy.grpc.proto.PingRequest;
 import org.alloytools.alloy.grpc.proto.PingResponse;
 import org.alloytools.alloy.grpc.proto.SolveRequest;
@@ -54,9 +57,24 @@ public class AlloySolverServiceImpl extends SolverServiceGrpc.SolverServiceImplB
                 return;
             }
 
-            // Load and parse the model
+            // Load and parse the model (single-file or multi-file mode)
             ModelLoader.CollectingReporter reporter = new ModelLoader.CollectingReporter();
-            ModelLoader.ModelLoadResult loadResult = ModelLoader.loadModel(request.getModelContent(), reporter);
+            ModelLoader.ModelLoadResult loadResult;
+            
+            // Determine whether to use single-file or multi-file mode
+            if (!request.getFilesList().isEmpty()) {
+                // Multi-file mode
+                // Convert AlloyFile list to Map<String, String>
+                Map<String, String> fileMap = new HashMap<>();
+                for (AlloyFile alloyFile : request.getFilesList()) {
+                    fileMap.put(alloyFile.getFilename(), alloyFile.getContent());
+                }
+                
+                loadResult = ModelLoader.loadModelFromFiles(fileMap, request.getMainFile(), reporter);
+            } else {
+                // Single-file mode (backward compatibility)
+                loadResult = ModelLoader.loadModel(request.getModelContent(), reporter);
+            }
             
             if (!loadResult.isSuccess()) {
                 responseObserver.onError(Status.fromCode(Status.Code.INVALID_ARGUMENT)
@@ -151,8 +169,43 @@ public class AlloySolverServiceImpl extends SolverServiceGrpc.SolverServiceImplB
      * Validate the solve request.
      */
     private ValidationResult validateRequest(SolveRequest request) {
-        if (request.getModelContent() == null || request.getModelContent().trim().isEmpty()) {
+        // Check if both single-file and multi-file are provided
+        boolean hasModelContent = !request.getModelContent().trim().isEmpty();
+        boolean hasFiles = !request.getFilesList().isEmpty();
+        
+        if (hasModelContent && hasFiles) {
+            return ValidationResult.error("Cannot specify both model_content and files. Use one or the other.");
+        }
+        
+        // For single-file mode, check for empty content (preserves backward compatibility)
+        if (!hasFiles && request.getModelContent().trim().isEmpty()) {
             return ValidationResult.error("Model content cannot be null or empty");
+        }
+        
+        if (!hasModelContent && !hasFiles) {
+            return ValidationResult.error("Either model_content or files must be provided");
+        }
+        
+        // Validate multi-file specific requirements
+        if (hasFiles) {
+            if (request.getMainFile().trim().isEmpty()) {
+                return ValidationResult.error("main_file must be specified when using multi-file mode");
+            }
+            
+            // Check that all files have valid filenames
+            for (AlloyFile file : request.getFilesList()) {
+                if (file.getFilename().trim().isEmpty()) {
+                    return ValidationResult.error("All files must have non-empty filenames");
+                }
+            }
+            
+            // Check that main_file exists in the files list
+            boolean mainFileExists = request.getFilesList().stream()
+                .anyMatch(file -> file.getFilename().equals(request.getMainFile()));
+            
+            if (!mainFileExists) {
+                return ValidationResult.error("main_file '" + request.getMainFile() + "' not found in provided files");
+            }
         }
 
         // Let the Alloy parser handle syntax validation - it gives better error messages

--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ModelLoader.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ModelLoader.java
@@ -1,10 +1,17 @@
 package org.alloytools.alloy.grpc.util;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import edu.mit.csail.sdg.alloy4.A4Reporter;
 import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.Util;
 import edu.mit.csail.sdg.ast.Command;
 import edu.mit.csail.sdg.parser.CompModule;
 import edu.mit.csail.sdg.parser.CompUtil;
@@ -84,6 +91,106 @@ public class ModelLoader {
             return ModelLoadResult.error("Parse error: " + err.getMessage());
         } catch (Exception ex) {
             return ModelLoadResult.error("Unexpected error: " + ex.getMessage());
+        }
+    }
+
+    /**
+     * Load and parse an Alloy model from multiple files with cross-file references.
+     * This method supports the 'open' directive by creating temporary files that
+     * can be resolved by Alloy's module system.
+     * 
+     * @param fileMap Map of filename to file content
+     * @param mainFile The main file to parse (must exist in fileMap)
+     * @param reporter The reporter for diagnostics (can be null)
+     * @return ModelLoadResult containing the parsed module or error information
+     */
+    public static ModelLoadResult loadModelFromFiles(Map<String, String> fileMap, String mainFile, A4Reporter reporter) {
+        if (fileMap == null || fileMap.isEmpty()) {
+            return ModelLoadResult.error("File map cannot be null or empty");
+        }
+
+        if (mainFile == null || mainFile.trim().isEmpty()) {
+            return ModelLoadResult.error("Main file cannot be null or empty");
+        }
+
+        if (!fileMap.containsKey(mainFile)) {
+            return ModelLoadResult.error("Main file '" + mainFile + "' not found in provided files");
+        }
+
+        if (reporter == null) {
+            reporter = A4Reporter.NOP;
+        }
+
+        Path tempDir = null;
+        try {
+            // Create temporary directory structure
+            tempDir = Files.createTempDirectory("alloy-grpc-");
+            
+            // Write all files to temporary directory, preserving relative paths
+            Map<String, String> fileCache = new HashMap<>();
+            for (Map.Entry<String, String> entry : fileMap.entrySet()) {
+                String filename = entry.getKey();
+                String content = entry.getValue();
+                
+                // Create parent directories if needed
+                Path filePath = tempDir.resolve(filename);
+                Files.createDirectories(filePath.getParent());
+                
+                // Write file content
+                Files.write(filePath, content.getBytes("UTF-8"));
+                
+                // Add to file cache for CompUtil
+                fileCache.put(filename, content);
+            }
+            
+            // Get the absolute path of the main file
+            Path mainFilePath = tempDir.resolve(mainFile);
+            String mainFileAbsolutePath = mainFilePath.toAbsolutePath().toString();
+            
+            // Parse using CompUtil with file cache
+            CompModule world = CompUtil.parseEverything_fromFile(reporter, fileCache, mainFileAbsolutePath);
+            
+            // Get all commands from the module
+            List<Command> commands = world.getAllCommands();
+            
+            return ModelLoadResult.success(world, commands);
+            
+        } catch (Err err) {
+            return ModelLoadResult.error("Parse error: " + err.getMessage());
+        } catch (IOException ex) {
+            return ModelLoadResult.error("IO error while creating temporary files: " + ex.getMessage());
+        } catch (Exception ex) {
+            return ModelLoadResult.error("Unexpected error: " + ex.getMessage());
+        } finally {
+            // Clean up temporary directory
+            if (tempDir != null) {
+                try {
+                    deleteDirectory(tempDir.toFile());
+                } catch (Exception e) {
+                    // Log warning but don't fail the operation
+                    System.err.println("Warning: Failed to delete temporary directory: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Recursively delete a directory and all its contents.
+     * 
+     * @param directory The directory to delete
+     * @throws IOException if deletion fails
+     */
+    private static void deleteDirectory(File directory) throws IOException {
+        if (directory.isDirectory()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    deleteDirectory(file);
+                }
+            }
+        }
+        if (!directory.delete()) {
+            throw new IOException("Failed to delete " + directory.getAbsolutePath());
         }
     }
 

--- a/org.alloytools.alloy.grpc/src/main/proto/alloy_solver.proto
+++ b/org.alloytools.alloy.grpc/src/main/proto/alloy_solver.proto
@@ -19,7 +19,8 @@ service SolverService {
 
 // Request message for solving an Alloy model
 message SolveRequest {
-  // The Alloy model source code to solve
+  // The Alloy model source code to solve (single file mode)
+  // Use this for backward compatibility or simple single-file models
   string model_content = 1;
   
   // Output format for the solution (default: JSON)
@@ -33,6 +34,26 @@ message SolveRequest {
   
   // Optional command to execute (if not specified, runs default command)
   string command = 5;
+  
+  // Multiple Alloy files (multi-file mode)
+  // Use this when your model uses 'open' directives to import other modules
+  repeated AlloyFile files = 6;
+  
+  // The main file to execute when using multi-file mode
+  // Must match the filename of one of the files in the 'files' array
+  // Example: "main.als" or "models/core.als"
+  string main_file = 7;
+}
+
+// Represents a single Alloy file for multi-file model solving
+message AlloyFile {
+  // The filename/path relative to the model root
+  // Examples: "util.als", "models/core.als", "library/sequences.als"
+  // This should match the path used in 'open' directives
+  string filename = 1;
+  
+  // The complete content of the Alloy file
+  string content = 2;
 }
 
 // Response message containing the solution

--- a/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/MultiFileSolvingIntegrationTest.java
+++ b/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/MultiFileSolvingIntegrationTest.java
@@ -1,0 +1,250 @@
+package org.alloytools.alloy.grpc.integration;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.alloytools.alloy.grpc.impl.AlloySolverServiceImpl;
+import org.alloytools.alloy.grpc.proto.AlloyFile;
+import org.alloytools.alloy.grpc.proto.OutputFormat;
+import org.alloytools.alloy.grpc.proto.SolveRequest;
+import org.alloytools.alloy.grpc.proto.SolveResponse;
+import org.alloytools.alloy.grpc.proto.SolverType;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * Integration tests for multi-file Alloy model solving via gRPC.
+ */
+public class MultiFileSolvingIntegrationTest {
+
+    private AlloySolverServiceImpl service;
+    private TestStreamObserver<SolveResponse> responseObserver;
+
+    @Before
+    public void setUp() {
+        service = new AlloySolverServiceImpl();
+        responseObserver = new TestStreamObserver<>();
+    }
+
+    @Test
+    public void testBasicMultiFileSolve() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("util.als")
+                .setContent("module util\nsig Util {}\npred hasUtil { some Util }"))
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("main.als")
+                .setContent("module main\nopen util\nrun { hasUtil } for 3"))
+            .setMainFile("main.als")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertTrue("Model should be satisfiable", response.getSatisfiable());
+        assertTrue("Error message should be empty", response.getErrorMessage().isEmpty());
+        assertFalse("Solution data should not be empty", response.getSolutionData().isEmpty());
+    }
+
+    @Test
+    public void testSimpleMultiFileImport() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("library.als")
+                .setContent("module library\nsig Container {}\npred hasContainer { some Container }"))
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("application.als")
+                .setContent("module application\nopen library\nrun { hasContainer } for 3"))
+            .setMainFile("application.als")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertTrue("Simple multi-file model should be satisfiable", response.getSatisfiable());
+        assertTrue("Error message should be empty", response.getErrorMessage().isEmpty());
+    }
+
+    @Test
+    public void testNestedDirectoryStructure() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("util/base.als")
+                .setContent("module util/base\nsig Base {}"))
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("util/derived.als")
+                .setContent("module util/derived\nopen util/base\nsig Derived extends Base {}"))
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("main.als")
+                .setContent("module main\nopen util/derived\nrun { some Derived } for 3"))
+            .setMainFile("main.als")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertTrue("Nested directory model should be satisfiable", response.getSatisfiable());
+    }
+
+    @Test
+    public void testErrorMissingMainFile() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("util.als")
+                .setContent("sig Util {}"))
+            .setMainFile("missing.als")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertFalse("Model should not be satisfiable", response.getSatisfiable());
+        assertFalse("Error message should not be empty", response.getErrorMessage().isEmpty());
+        assertTrue("Error message should mention main file", 
+            response.getErrorMessage().toLowerCase().contains("main"));
+    }
+
+    @Test
+    public void testErrorEmptyMainFile() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("util.als")
+                .setContent("sig Util {}"))
+            .setMainFile("")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertFalse("Model should not be satisfiable", response.getSatisfiable());
+        assertFalse("Error message should not be empty", response.getErrorMessage().isEmpty());
+        assertTrue("Error message should mention main_file", 
+            response.getErrorMessage().toLowerCase().contains("main_file"));
+    }
+
+    @Test
+    public void testErrorEmptyFilename() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("")
+                .setContent("sig Util {}"))
+            .setMainFile("main.als")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertFalse("Model should not be satisfiable", response.getSatisfiable());
+        assertFalse("Error message should not be empty", response.getErrorMessage().isEmpty());
+        assertTrue("Error message should mention filename", 
+            response.getErrorMessage().toLowerCase().contains("filename"));
+    }
+
+    @Test
+    public void testErrorBothModelContentAndFiles() throws Exception {
+        SolveRequest request = SolveRequest.newBuilder()
+            .setModelContent("sig Test {}")
+            .addFiles(AlloyFile.newBuilder()
+                .setFilename("util.als")
+                .setContent("sig Util {}"))
+            .setMainFile("util.als")
+            .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
+            .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .build();
+
+        service.solve(request, responseObserver);
+
+        assertTrue("Response should be received", responseObserver.hasResponse());
+        assertFalse("Should not have gRPC error", responseObserver.hasError());
+
+        SolveResponse response = responseObserver.getResponse();
+        assertFalse("Model should not be satisfiable", response.getSatisfiable());
+        assertFalse("Error message should not be empty", response.getErrorMessage().isEmpty());
+        assertTrue("Error message should mention both", 
+            response.getErrorMessage().toLowerCase().contains("both") ||
+            response.getErrorMessage().toLowerCase().contains("cannot specify"));
+    }
+
+
+
+
+    /**
+     * Test stream observer implementation for capturing responses and errors.
+     */
+    private static class TestStreamObserver<T> implements StreamObserver<T> {
+        private final CompletableFuture<T> future = new CompletableFuture<>();
+        private final CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+        private volatile boolean completed = false;
+
+        @Override
+        public void onNext(T value) {
+            future.complete(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            errorFuture.complete(t);
+        }
+
+        @Override
+        public void onCompleted() {
+            completed = true;
+            if (!future.isDone()) {
+                future.complete(null);
+            }
+        }
+
+        public boolean hasResponse() {
+            return future.isDone() && !errorFuture.isDone();
+        }
+
+        public boolean hasError() {
+            return errorFuture.isDone();
+        }
+
+        public T getResponse() throws InterruptedException, ExecutionException, TimeoutException {
+            return future.get(5, TimeUnit.SECONDS);
+        }
+
+        public Throwable getError() throws InterruptedException, ExecutionException, TimeoutException {
+            return errorFuture.get(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/util/MultiFileModelLoaderTest.java
+++ b/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/util/MultiFileModelLoaderTest.java
@@ -1,0 +1,205 @@
+package org.alloytools.alloy.grpc.util;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import edu.mit.csail.sdg.alloy4.A4Reporter;
+
+/**
+ * Unit tests for multi-file model loading functionality.
+ */
+public class MultiFileModelLoaderTest {
+
+    @Test
+    public void testBasicMultiFileLoading() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util.als", "module util\nsig Util {}\npred hasUtil { some Util }");
+        fileMap.put("main.als", "module main\nopen util\nrun { hasUtil } for 3");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertTrue("Model should load successfully", result.isSuccess());
+        assertNotNull("Module should not be null", result.getModule());
+        assertFalse("Commands should not be empty", result.getCommands().isEmpty());
+    }
+
+    @Test
+    public void testParameterizedModules() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("lib.als", 
+            "module lib[T]\n" +
+            "sig Container { items: set T }\n" +
+            "pred hasItems[c: Container] { some c.items }");
+        fileMap.put("app.als", 
+            "module app\n" +
+            "open lib[Int] as library\n" +
+            "run { some c: library/Container | library/hasItems[c] } for 3");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "app.als", A4Reporter.NOP);
+        
+        assertTrue("Parameterized module should load successfully", result.isSuccess());
+        assertNotNull("Module should not be null", result.getModule());
+        assertFalse("Commands should not be empty", result.getCommands().isEmpty());
+    }
+
+    @Test
+    public void testNestedDirectoryStructure() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util/base.als", "module util/base\nsig Base {}");
+        fileMap.put("util/derived.als", "module util/derived\nopen util/base\nsig Derived extends Base {}");
+        fileMap.put("main.als", "module main\nopen util/derived\nrun { some Derived } for 3");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertTrue("Nested directory structure should work", result.isSuccess());
+        assertNotNull("Module should not be null", result.getModule());
+    }
+
+    @Test
+    public void testThreeLevelImportChain() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("base.als", "module base\nsig Element {}");
+        fileMap.put("middle.als", "module middle\nopen base\nsig Container { contents: set Element }");
+        fileMap.put("top.als", "module top\nopen middle\nrun { some Container } for 3");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "top.als", A4Reporter.NOP);
+        
+        assertTrue("Three-level import chain should work", result.isSuccess());
+        assertNotNull("Module should not be null", result.getModule());
+    }
+
+    @Test
+    public void testErrorEmptyFileMap() {
+        Map<String, String> fileMap = new HashMap<>();
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertFalse("Empty file map should fail", result.isSuccess());
+        assertTrue("Error message should mention empty", 
+            result.getErrorMessage().toLowerCase().contains("empty"));
+    }
+
+    @Test
+    public void testErrorNullFileMap() {
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(null, "main.als", A4Reporter.NOP);
+        
+        assertFalse("Null file map should fail", result.isSuccess());
+        assertTrue("Error message should mention null", 
+            result.getErrorMessage().toLowerCase().contains("null"));
+    }
+
+    @Test
+    public void testErrorEmptyMainFile() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util.als", "sig Util {}");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "", A4Reporter.NOP);
+        
+        assertFalse("Empty main file should fail", result.isSuccess());
+        assertTrue("Error message should mention empty", 
+            result.getErrorMessage().toLowerCase().contains("empty"));
+    }
+
+    @Test
+    public void testErrorNullMainFile() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util.als", "sig Util {}");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, null, A4Reporter.NOP);
+        
+        assertFalse("Null main file should fail", result.isSuccess());
+        assertTrue("Error message should mention null", 
+            result.getErrorMessage().toLowerCase().contains("null"));
+    }
+
+    @Test
+    public void testErrorMainFileNotFound() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util.als", "sig Util {}");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "missing.als", A4Reporter.NOP);
+        
+        assertFalse("Missing main file should fail", result.isSuccess());
+        assertTrue("Error message should mention not found", 
+            result.getErrorMessage().toLowerCase().contains("not found"));
+    }
+
+    @Test
+    public void testErrorSyntaxError() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("main.als", "invalid syntax {{{");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertFalse("Syntax error should fail", result.isSuccess());
+        assertTrue("Error message should mention parse", 
+            result.getErrorMessage().toLowerCase().contains("parse"));
+    }
+
+    @Test
+    public void testErrorMissingImport() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("main.als", "module main\nopen nonexistent\nsig Main {}");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertFalse("Missing import should fail", result.isSuccess());
+        assertNotNull("Error message should be provided", result.getErrorMessage());
+    }
+
+    @Test
+    public void testWithReporter() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util.als", "module util\nsig Util {}");
+        fileMap.put("main.als", "module main\nopen util\nrun { some Util } for 3");
+        
+        ModelLoader.CollectingReporter reporter = new ModelLoader.CollectingReporter();
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", reporter);
+        
+        assertTrue("Model should load successfully with reporter", result.isSuccess());
+        assertFalse("Should not have errors", reporter.hasErrors());
+    }
+
+    @Test
+    public void testFilenameCaseSensitivity() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("Util.als", "module Util\nsig UtilSig {}");
+        fileMap.put("main.als", "module main\nopen Util\nrun { some UtilSig } for 3");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertTrue("Case-sensitive filenames should work", result.isSuccess());
+    }
+
+    @Test
+    public void testFileWithInvalidContent() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("invalid.als", "invalid alloy syntax {{{");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "invalid.als", A4Reporter.NOP);
+        
+        // This should fail because of invalid syntax
+        assertFalse("Invalid syntax should cause parsing to fail", result.isSuccess());
+        assertNotNull("Error message should be provided", result.getErrorMessage());
+    }
+
+    @Test
+    public void testMultipleCommandsInMainFile() {
+        Map<String, String> fileMap = new HashMap<>();
+        fileMap.put("util.als", "module util\nsig Util {}");
+        fileMap.put("main.als", 
+            "module main\n" +
+            "open util\n" +
+            "run { some Util } for 3\n" +
+            "check { all u: Util | some u } for 3");
+        
+        ModelLoader.ModelLoadResult result = ModelLoader.loadModelFromFiles(fileMap, "main.als", A4Reporter.NOP);
+        
+        assertTrue("Model should load successfully", result.isSuccess());
+        assertEquals("Should have 2 commands", 2, result.getCommands().size());
+    }
+}


### PR DESCRIPTION
This commit extends the gRPC server to handle multiple Alloy files with cross-file symbol references using the 'open' directive.

Key Features:
- Extended Protocol Buffer API with AlloyFile message and repeated files field
- Enhanced ModelLoader with loadModelFromFiles() method supporting temporary file system
- Updated AlloySolverServiceImpl to handle both single-file and multi-file requests
- Comprehensive validation for multi-file scenarios with detailed error messages
- Backward compatibility maintained for existing single-file API

Implementation Details:
- Supports basic imports, parameterized modules, nested directory structures, and module aliases
- Uses CompUtil.parseEverything_fromFile() with file cache for proper module resolution
- Creates temporary directory structure to preserve relative paths for import resolution
- Safe cleanup of temporary files after processing

Testing & Documentation:
- Added 15 unit tests for ModelLoader multi-file functionality
- Added 7 integration tests for gRPC service multi-file scenarios
- Enhanced test-server.sh with multi-file test cases
- Created comprehensive test-multifile-examples.sh script
- Updated README with extensive multi-file examples and troubleshooting guide

Files Changed:
- alloy_solver.proto: Added AlloyFile message and multi-file fields
- ModelLoader.java: Added loadModelFromFiles() method with temp file handling
- AlloySolverServiceImpl.java: Extended solve() method for multi-file support
- README.md: Comprehensive documentation with examples and troubleshooting
- test scripts: Enhanced testing coverage for multi-file scenarios
- New test classes: MultiFileModelLoaderTest, MultiFileSolvingIntegrationTest

All existing functionality remains unchanged and all tests pass.