### PR TITLE
Fix broken Dockerfile and update deployment docs

### DIFF
--- a/org.alloytools.alloy.grpc/Dockerfile
+++ b/org.alloytools.alloy.grpc/Dockerfile
@@ -1,12 +1,5 @@
 # Multi-stage build for Alloy gRPC Service
-FROM openjdk:17-jdk-slim as builder
-
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    wget \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+FROM eclipse-temurin:17-jdk-jammy AS builder
 
 # Set working directory
 WORKDIR /app
@@ -16,25 +9,24 @@ COPY gradlew gradlew.bat ./
 COPY .gradle-wrapper/ .gradle-wrapper/
 COPY build.gradle settings.gradle gradle.properties ./
 
-# Copy source code
+# Copy bnd workspace config (required by the bnd workspace Gradle plugin)
 COPY cnf/ cnf/
-COPY org.alloytools.alloy.core/ org.alloytools.alloy.core/
-COPY org.alloytools.alloy.dist/ org.alloytools.alloy.dist/
+
+# Copy only the gRPC module — it uses pre-built JARs from its own lib/ directory,
+# so sibling module sources (alloy.core, api, pardinus, etc.) are not needed.
+# Copying them would cause the bnd workspace plugin to discover their bnd.bnd files
+# and fail during configuration due to missing transitive dependencies.
 COPY org.alloytools.alloy.grpc/ org.alloytools.alloy.grpc/
-COPY org.alloytools.api/ org.alloytools.api/
-COPY org.alloytools.pardinus.core/ org.alloytools.pardinus.core/
 
 # Build the application and create distribution
 RUN chmod +x gradlew && ./gradlew :org.alloytools.alloy.grpc:build :org.alloytools.alloy.grpc:distTar -x test
 
-# Production stage
-FROM openjdk:17-jdk-slim
+# Production stage — JRE is sufficient for running the server
+FROM eclipse-temurin:17-jre-jammy
 
-# Install runtime dependencies and health check tools
-RUN apt-get update && apt-get install -y \
-    curl \
+# Install health check tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
-    netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security

--- a/org.alloytools.alloy.grpc/README.md
+++ b/org.alloytools.alloy.grpc/README.md
@@ -12,9 +12,10 @@ A gRPC service for Alloy 6 that exposes model solving capabilities through a wel
 ## Installation
 
 ### Prerequisites
-- Java 11+
-- Gradle 7.0+
+- Java 17+
+- Gradle 7.2+ (via included wrapper)
 - grpcurl (optional, for testing)
+- Docker (optional, for containerized deployment)
 
 ### Building
 ```bash
@@ -210,18 +211,32 @@ grpcurl -plaintext -d "$(jq -n \
 
 ### Docker
 
+The Dockerfile uses a multi-stage build. The builder stage compiles only the gRPC
+module (it uses pre-built JARs from `lib/`, not sibling module sources). The
+runtime stage uses an Eclipse Temurin JRE image.
+
 ```bash
-# Build image
+# Build image (run from the repo root)
 docker build -f org.alloytools.alloy.grpc/Dockerfile -t alloy-grpc:latest .
 
 # Run container
 docker run -p 50051:50051 alloy-grpc:latest
+
+# Run with custom port and JVM settings
+docker run -p 8080:8080 \
+  -e GRPC_PORT=8080 \
+  -e JAVA_OPTS="-Xmx4g -Xms1g" \
+  alloy-grpc:latest
 ```
 
-### GCloud deployment
+### Google Cloud Build + Cloud Run
+
 ```bash
 gcloud builds submit --config=org.alloytools.alloy.grpc/cloudbuild.yaml .
 ```
+
+This builds the Docker image, pushes it to Artifact Registry, and deploys to
+Cloud Run. See [cloudbuild.yaml](cloudbuild.yaml) for the full pipeline.
 
 ### Environment Variables
 
@@ -229,21 +244,6 @@ gcloud builds submit --config=org.alloytools.alloy.grpc/cloudbuild.yaml .
 |----------|---------|-------------|
 | `JAVA_OPTS` | `-Xmx2g -Xms512m` | JVM options |
 | `GRPC_PORT` | `50051` | gRPC server port |
-
-### JVM Tuning
-
-For production workloads, adjust JVM settings based on your requirements:
-
-```bash
-# For high-throughput scenarios
-JAVA_OPTS="-Xmx8g -Xms2g -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
-
-# For low-latency scenarios
-JAVA_OPTS="-Xmx4g -Xms4g -XX:+UseZGC"
-
-# For memory-constrained environments
-JAVA_OPTS="-Xmx1g -Xms512m -XX:+UseSerialGC"
-```
 
 ## Project Structure
 

--- a/org.alloytools.alloy.grpc/README.md
+++ b/org.alloytools.alloy.grpc/README.md
@@ -245,6 +245,21 @@ Cloud Run. See [cloudbuild.yaml](cloudbuild.yaml) for the full pipeline.
 | `JAVA_OPTS` | `-Xmx2g -Xms512m` | JVM options |
 | `GRPC_PORT` | `50051` | gRPC server port |
 
+### JVM Tuning
+
+For production workloads, adjust JVM settings based on your requirements:
+
+```bash
+# For high-throughput scenarios
+JAVA_OPTS="-Xmx8g -Xms2g -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
+
+# For low-latency scenarios
+JAVA_OPTS="-Xmx4g -Xms4g -XX:+UseZGC"
+
+# For memory-constrained environments
+JAVA_OPTS="-Xmx1g -Xms512m -XX:+UseSerialGC"
+```
+
 ## Project Structure
 
 The Alloy gRPC service module is organized into the following directory structure:


### PR DESCRIPTION
## Summary
- Replace deprecated `openjdk:17-jdk-slim` with `eclipse-temurin` images (JDK for builder, JRE for runtime)
- Remove unnecessary COPY of sibling module sources (`alloy.core`, `api`, `pardinus`, etc.) — the gRPC module uses pre-built JARs from `lib/`, and copying `bnd.bnd`-containing directories caused the bnd workspace plugin to fail during configuration
- Remove unused build/runtime dependencies (`git`, `unzip`, `curl`, `netcat-openbsd`)
- Update README: fix prerequisites (Java 17+, not 11+), improve Docker/deploy section

## Test plan
- [x] Docker image builds successfully
- [x] Container starts and serves on configured port
- [x] Ping endpoint responds with solver info
- [x] Solve endpoint returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)